### PR TITLE
Refactor migration logic into separate migrate.go file

### DIFF
--- a/sqlrl/migrate.go
+++ b/sqlrl/migrate.go
@@ -1,0 +1,58 @@
+package sqlrl
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"gorm.io/gorm"
+)
+
+// Migrate creates the required table if it doesn't exist.
+// This method follows the database design standards and handles concurrent migration attempts.
+// It's safe to call this method multiple times - it will only create the table if it doesn't exist.
+//
+// The created table structure follows these principles:
+// - Uses VARCHAR(255) for key column to provide format flexibility
+// - Uses BIGINT for time storage (unix microseconds)
+// - No foreign keys (logical relationships only)
+// - Optimized for rate limiting workloads
+func Migrate(ctx context.Context, db *gorm.DB, tableName string) error {
+	// Build CREATE TABLE statement according to database design standards
+	createTableSQL := fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (
+			%s VARCHAR(255) PRIMARY KEY NOT NULL,
+			%s BIGINT NOT NULL
+		)
+	`, tableName, ColumnKey, ColumnTimeToAct)
+
+	// Retry mechanism to handle concurrent table creation
+	for attempts := 0; attempts < MaxMigrationAttempts; attempts++ {
+		err := db.WithContext(ctx).Exec(createTableSQL).Error
+		if err == nil {
+			return nil
+		}
+
+		if attempts == MaxMigrationAttempts-1 {
+			return errors.Wrap(err, "failed to create table")
+		}
+
+		errMsg := err.Error()
+		// Handle PostgreSQL concurrent table creation conflicts
+		if strings.Contains(errMsg, `duplicate key value violates unique constraint`) ||
+			strings.Contains(errMsg, "already exists (SQLSTATE 42P07)") {
+			select {
+			case <-ctx.Done():
+				return errors.Wrap(ctx.Err(), "migration cancelled during backoff")
+			case <-time.After(time.Duration(100+rand.Intn(100)) * time.Millisecond):
+			}
+			continue
+		}
+
+		return errors.Wrap(err, "failed to create table")
+	}
+	return nil
+}

--- a/sqlrl/sql.go
+++ b/sqlrl/sql.go
@@ -3,7 +3,6 @@ package sqlrl
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"strings"
 	"time"
 
@@ -83,49 +82,8 @@ func New(db *gorm.DB, tableName string) (*RateLimiter, error) {
 }
 
 // Migrate creates the required table if it doesn't exist.
-// This method follows the database design standards and handles concurrent migration attempts.
-// It's safe to call this method multiple times - it will only create the table if it doesn't exist.
-//
-// The created table structure follows these principles:
-// - Uses VARCHAR(255) for key column to provide format flexibility
-// - Uses BIGINT for time storage (unix microseconds)
-// - No foreign keys (logical relationships only)
-// - Optimized for rate limiting workloads
 func (s *RateLimiter) Migrate(ctx context.Context) error {
-	// Build CREATE TABLE statement according to database design standards
-	createTableSQL := fmt.Sprintf(`
-		CREATE TABLE IF NOT EXISTS %s (
-			%s VARCHAR(255) PRIMARY KEY NOT NULL,
-			%s BIGINT NOT NULL
-		)
-	`, s.tableName, ColumnKey, ColumnTimeToAct)
-
-	// Retry mechanism to handle concurrent table creation
-	for attempts := 0; attempts < MaxMigrationAttempts; attempts++ {
-		err := s.db.WithContext(ctx).Exec(createTableSQL).Error
-		if err == nil {
-			return nil
-		}
-
-		if attempts == MaxMigrationAttempts-1 {
-			return errors.Wrap(err, "failed to create table")
-		}
-
-		errMsg := err.Error()
-		// Handle PostgreSQL concurrent table creation conflicts
-		if strings.Contains(errMsg, `duplicate key value violates unique constraint`) ||
-			strings.Contains(errMsg, "already exists (SQLSTATE 42P07)") {
-			select {
-			case <-ctx.Done():
-				return errors.Wrap(ctx.Err(), "migration cancelled during backoff")
-			case <-time.After(time.Duration(100+rand.Intn(100)) * time.Millisecond):
-			}
-			continue
-		}
-
-		return errors.Wrap(err, "failed to create table")
-	}
-	return nil
+	return Migrate(ctx, s.db, s.tableName)
 }
 
 type kvWrapper struct {


### PR DESCRIPTION
Moved the table migration logic from the RateLimiter struct in sql.go to a standalone Migrate function in a new migrate.go file. This improves code organization and reusability by allowing migration to be called independently of the RateLimiter instance.

<!--
Thanks for opening a pull request!
Please read through this and fill out the checks. If they're not relevant, put N/A there.
-->

## Type of change

<!--
Add one or more of the following kinds:
- bug
- feature
- documentation
- configuration
- cleanup
- deployment (for another change)
-->

## Description

<!--
What's the change? Why do we need it?
-->

## Related issues

<!--
Which Jira issue are you resolving? Put all references here.
-->

## Notes for reviewer

<!--
What else does a reviewer need to know?
-->
